### PR TITLE
feat: MongoDB now loads configuration from secrets and container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # VS Code
 *.vscode
 
+# .local
+.local
+
 # Flag tools
 flag_tool
 

--- a/MiniTwit.Core/IMongoDBContext.cs
+++ b/MiniTwit.Core/IMongoDBContext.cs
@@ -5,7 +5,6 @@ namespace MiniTwit.Core;
 
 public interface IMongoDBContext
 {
-    IMongoDatabase MongoDatabase { get; init; }
     IMongoCollection<User> Users { get; init; }
     IMongoCollection<Follower> Followers { get; init; }
     IMongoCollection<Message> Messages { get; init; }

--- a/MiniTwit.Core/MiniTwitDatabaseSettings.cs
+++ b/MiniTwit.Core/MiniTwitDatabaseSettings.cs
@@ -1,0 +1,10 @@
+namespace MiniTwit.Core;
+
+public class MiniTwitDatabaseSettings
+{
+    public string ConnectionString { get; set; } = null!;
+    public string Database { get; set; } = null!;
+    public string UsersCollectionName { get; set; } = null!;
+    public string TweetsCollectionName { get; set; } = null!;
+    public string FollowersCollectionName { get; set; } = null!;
+}

--- a/MiniTwit.Infrastructure/MongoDBContext.cs
+++ b/MiniTwit.Infrastructure/MongoDBContext.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Options;
 using MiniTwit.Core;
 using MiniTwit.Core.Entities;
 using MongoDB.Driver;
@@ -6,17 +7,18 @@ namespace MiniTwit.Infrastructure;
 
 public class MongoDBContext : IMongoDBContext
 {
-    public IMongoDatabase MongoDatabase { get; init; }
     public IMongoCollection<User> Users { get; init; }
     public IMongoCollection<Follower> Followers { get; init; }
 
     public IMongoCollection<Message> Messages { get; init; }
 
-    public MongoDBContext()
+    public MongoDBContext(IOptions<MiniTwitDatabaseSettings> databaseSettings)
     {
-        MongoDatabase = new MongoClient("mongodb://localhost:27017").GetDatabase("minitwit");
-        Users = MongoDatabase.GetCollection<User>("user");
-        Followers = MongoDatabase.GetCollection<Follower>("follower");
-        Messages = MongoDatabase.GetCollection<Message>("message");
+        var mongoClient = new MongoClient(databaseSettings.Value.ConnectionString);
+        var mongoDatabase = mongoClient.GetDatabase(databaseSettings.Value.Database);
+
+        Users = mongoDatabase.GetCollection<User>(databaseSettings.Value.UsersCollectionName);
+        Followers = mongoDatabase.GetCollection<Follower>(databaseSettings.Value.FollowersCollectionName);
+        Messages = mongoDatabase.GetCollection<Message>(databaseSettings.Value.TweetsCollectionName);
     }
 }

--- a/MiniTwit.Server/MiniTwit.Server.csproj
+++ b/MiniTwit.Server/MiniTwit.Server.csproj
@@ -1,9 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>0a60ddcd-86b0-42db-9216-996d71456e52</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MiniTwit.Server/Program.cs
+++ b/MiniTwit.Server/Program.cs
@@ -5,7 +5,15 @@ using MiniTwit.Infrastructure.Repositories;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Add user-secrets if running in container
+builder.Configuration.AddKeyPerFile("/run/secrets", optional: true);
+
 // Add services to the container.
+
+// Configure MongoDB
+var dbSettings = builder.Configuration.GetSection(nameof(MiniTwitDatabaseSettings));
+builder.Services.Configure<MiniTwitDatabaseSettings>(dbSettings);
+builder.Services.Configure<MiniTwitDatabaseSettings>(options => options.ConnectionString = builder.Configuration.GetConnectionString("MiniTwit")!);
 
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
@@ -21,7 +29,13 @@ var app = builder.Build();
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
-    app.UseSwaggerUI();
+    app.UseSwaggerUI(options =>
+    {
+        options.SwaggerEndpoint("/swagger/v1/swagger.json", "MiniTwit API");
+        options.DocumentTitle = "Swagger - MiniTwit API";
+        options.RoutePrefix = string.Empty;
+        options.DisplayRequestDuration();
+    });
 }
 
 app.UseHttpsRedirection();

--- a/MiniTwit.Server/appsettings.Development.json
+++ b/MiniTwit.Server/appsettings.Development.json
@@ -1,4 +1,10 @@
 {
+  "MiniTwitDatabaseSettings": {
+    "Database": "MiniTwit",
+    "UsersCollectionName": "Users",
+    "TweetsCollectionName": "Tweets",
+    "FollowersCollectionName": "Followers"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,15 @@ services:
   mongodb:
     image: mongodb/mongodb-community-server:6.0-ubi8
     environment:
-      - MONGO_INITDB_ROOT_USERNAME=radiator
-      - MONGO_INITDB_ROOT_PASSWORD=TqqW1zCn3XO2r0vkjjy5g1Y7AjWxOt
+      MONGO_INITDB_ROOT_USERNAME: radiator
+      MONGO_INITDB_ROOT_PASSWORD_FILE: run/secrets/db_password
+      MONGO_INITDB_DATABASE: MiniTwit
     volumes:
       - mongodb_data_container:/data/db
     ports:
       - '27017:27017'
+    secrets:
+      - db_password
 
   itu-minitwit-server:
     image: itu-minitwit-server
@@ -21,10 +24,14 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: Development
       ASPNETCORE_URLS: http://+:80
+      ConnectionStrings__MiniTwit:
     ports:
       - '80:80'
     depends_on:
       - mongodb
+    secrets:
+      - source: connection_string
+        target: ConnectionStrings__MiniTwit
 
   itu-minitwit-web:
     image: itu-minitwit-web
@@ -38,3 +45,9 @@ services:
 
 volumes:
   mongodb_data_container:
+
+secrets:
+  db_password:
+    file: './.local/db_password.txt'
+  connection_string:
+    file: './.local/connection_string.txt'

--- a/run.sh
+++ b/run.sh
@@ -13,6 +13,15 @@ if [ "$#" -eq 0 ]; then
 elif [ "$1" = "stop" ]; then
     printf "${green}Stopping container\n${clear}"
     docker-compose stop
+elif [ "$1" = "secrets" ]; then
+    printf "${green}Creating secrets...\n${clear}"
+    project="MiniTwit.Server"
+    user="radiator"
+    password=$(<./.local/db_password.txt) # Load db password from file
+    connectionString="mongodb://$user:$password@localhost:27017"
+
+    dotnet user-secrets init --project $project
+    dotnet user-secrets set "ConnectionStrings:MiniTwit" "$connectionString" --project $project
 else
     printf "${red}Error: Unknown command\n${clear}"
 fi


### PR DESCRIPTION
* Implemented user-secrets loading of connection strings and MongoDB settings when run with dotnet run
* docker-compose now uses docker secrets to store database password and connection string

See notion page under the section "How to initialize MiniTwit" for how to set up secrets.