### PR TITLE
Fix swagger auth

### DIFF
--- a/MiniTwit.Core/Error/ErrorType.cs
+++ b/MiniTwit.Core/Error/ErrorType.cs
@@ -11,12 +11,13 @@ public enum ErrorType
     USERNAME_TAKEN,
     USERNAME_MISSING,
     PASSWORD_MISSING,
-    EMAIL_MISSING_OR_INVALID
+    EMAIL_MISSING_OR_INVALID,
+    UNAUTHORIZED_CREDENTIALS
 }
 
 public static class ErrorTypeExtensions
 {
-    public static string ErrorMsg(this ErrorType? errorType) => errorType switch
+    public static string ErrorMsg(this ErrorType errorType) => errorType switch
     {
         INVALID_USER_ID => "Invalid user id",
         INVALID_USERNAME => "Invalid username",
@@ -25,10 +26,13 @@ public static class ErrorTypeExtensions
         USERNAME_MISSING => "You have to enter a username",
         PASSWORD_MISSING => "You have to enter a password",
         EMAIL_MISSING_OR_INVALID => "You have to enter a valid email address",
+        UNAUTHORIZED_CREDENTIALS => "You are not authorized to use this resource!",
         _ => "Unknown error"
     };
 
-    public static APIError ToAPIError(this ErrorType? errorType, HTTPResponse HTTPResponse)
+    public static string ErrorMsg(this ErrorType? errorType) => ErrorMsg((ErrorType) errorType!);
+
+    public static APIError ToAPIError(this ErrorType errorType, HTTPResponse HTTPResponse)
     {
         return new APIError
         {
@@ -36,4 +40,6 @@ public static class ErrorTypeExtensions
             ErrorMsg = errorType.ErrorMsg()
         };
     }
+
+    public static APIError ToAPIError(this ErrorType? errorType, HTTPResponse HTTPResponse) => ToAPIError((ErrorType) errorType!, HTTPResponse);
 }

--- a/MiniTwit.Core/Responses/HTTPResponse.cs
+++ b/MiniTwit.Core/Responses/HTTPResponse.cs
@@ -7,6 +7,7 @@ public enum HTTPResponse
     NoContent = 204,
     BadRequest = 400,
     Unauthorized = 401,
+    Forbidden = 403,
     NotFound = 404,
     Conflict = 409
 }

--- a/MiniTwit.Server/Authentication/BasicAuthenticationHandler.cs
+++ b/MiniTwit.Server/Authentication/BasicAuthenticationHandler.cs
@@ -1,0 +1,49 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
+using MiniTwit.Core.Error;
+using MiniTwit.Core.Responses;
+
+namespace MiniTwit.Server.Authentication;
+
+public class BasicAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public BasicAuthenticationHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock) : base(options, logger, encoder, clock) { }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        // Convert 401 to 403 and attach APIError
+        SetupResponseConverter();
+
+        // Get auth header
+        var authHeader = Request.Headers[HeaderNames.Authorization].ToString();
+
+        if (authHeader != null && authHeader.StartsWith("basic", StringComparison.OrdinalIgnoreCase))
+        {
+            if (authHeader == "Basic c2ltdWxhdG9yOnN1cGVyX3NhZmUh")
+            {
+                var claims = new[] { new Claim("name", "simulator"), new Claim(ClaimTypes.Role, "Simulator") };
+                var identity = new ClaimsIdentity(claims, "Basic");
+                var claimsPrincipal = new ClaimsPrincipal(identity);
+
+                return Task.FromResult(AuthenticateResult.Success(new AuthenticationTicket(claimsPrincipal, Scheme.Name)));
+            }
+        }
+
+        return Task.FromResult(AuthenticateResult.Fail("Invalid Authorization Header"));
+    }
+
+    private void SetupResponseConverter()
+    {
+        Context.Response.OnStarting(async (state) =>
+       {
+           if (Response.StatusCode == StatusCodes.Status401Unauthorized)
+           {
+               Response.StatusCode = StatusCodes.Status403Forbidden;
+               await Response.WriteAsJsonAsync<APIError>(ErrorType.UNAUTHORIZED_CREDENTIALS.ToAPIError(HTTPResponse.Forbidden));
+           }
+       }, null!);
+    }
+}

--- a/MiniTwit.Server/Authentication/SwaggerAuthOperationFilter.cs
+++ b/MiniTwit.Server/Authentication/SwaggerAuthOperationFilter.cs
@@ -1,0 +1,29 @@
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace MiniTwit.Server.Authentication;
+
+public class SwaggerAuthOperationFilter : IOperationFilter
+{
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+        if (operation.Parameters == null)
+        {
+            operation.Parameters = new List<OpenApiParameter>();
+        }
+
+        var scheme = new OpenApiSecurityScheme
+        {
+            Reference = new OpenApiReference
+            {
+                Id = "Basic Authentication",
+                Type = ReferenceType.SecurityScheme
+            }
+        };
+
+        operation.Security.Add(new OpenApiSecurityRequirement
+        {
+            [scheme] = new List<string>()
+        });
+    }
+}

--- a/MiniTwit.Server/Controllers/TwitterController.cs
+++ b/MiniTwit.Server/Controllers/TwitterController.cs
@@ -22,7 +22,7 @@ public class TwitterController : ControllerBase
     /// Shows a users timeline or if no user is logged in it will
     /// redirect to the public timeline. This timeline shows the user's
     /// messages as well as all the messages of followed users.
-    /// <summary>
+    /// </summary>
     [HttpGet]
     [AllowAnonymous]
     [ProducesResponseType(StatusCodes.Status200OK)]
@@ -38,7 +38,7 @@ public class TwitterController : ControllerBase
 
     /// <summary>
     /// Displays the latest messages of all users.
-    /// <summary>
+    /// </summary>
     [HttpGet]
     [AllowAnonymous]
     [ProducesResponseType(StatusCodes.Status200OK)]
@@ -51,7 +51,7 @@ public class TwitterController : ControllerBase
 
     /// <summary>
     /// Display's a users tweets.
-    /// <summary>
+    /// </summary>
     [HttpGet]
     [AllowAnonymous]
     [ProducesResponseType(StatusCodes.Status200OK)]
@@ -65,7 +65,7 @@ public class TwitterController : ControllerBase
 
     /// <summary>
     /// Adds the current user as follower of the given user.
-    /// <summary>
+    /// </summary>
     [HttpPost]
     [AllowAnonymous]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
@@ -79,7 +79,7 @@ public class TwitterController : ControllerBase
 
     /// <summary>
     /// Removes the current user as follower of the given user.
-    /// <summary>
+    /// </summary>
     [HttpDelete]
     [AllowAnonymous]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
@@ -93,7 +93,7 @@ public class TwitterController : ControllerBase
 
     /// <summary>
     /// Registers a new message for the user.
-    /// <summary>
+    /// </summary>
     [HttpPost]
     [AllowAnonymous]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
@@ -107,7 +107,7 @@ public class TwitterController : ControllerBase
 
     /// <summary>
     /// Logs the user in.
-    /// <summary>
+    /// </summary>
     [HttpPost]
     [AllowAnonymous]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
@@ -121,7 +121,7 @@ public class TwitterController : ControllerBase
 
     /// <summary>
     /// Registers the user.
-    /// <summary>
+    /// </summary>
     [HttpPost]
     [AllowAnonymous]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
@@ -135,7 +135,7 @@ public class TwitterController : ControllerBase
 
     /// <summary>
     /// Logs out the user
-    /// <summary>
+    /// </summary>
     [HttpDelete]
     [AllowAnonymous]
     [ProducesResponseType(StatusCodes.Status200OK)]

--- a/MiniTwit.Server/Extensions/ServiceCollectionExtensions.cs
+++ b/MiniTwit.Server/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,38 @@
+using System.Reflection;
+using Microsoft.OpenApi.Models;
+using MiniTwit.Server.Authentication;
+
+namespace MiniTwit.Server.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection ConfigureSwagger(this IServiceCollection services)
+    {
+        services.AddEndpointsApiExplorer();
+        services.AddSwaggerGen(options =>
+        {
+            options.SwaggerDoc("v1", new OpenApiInfo()
+            {
+                Title = "MiniTwit API",
+                Version = "v1",
+                Description = "A refactor of a Twitter clone handed out in the elective course DevOps on the IT University of Copenhagen.",
+                Contact = new OpenApiContact() { Name = "Group Radiator" },
+            });
+
+            // Add Basic Authentication option for API explorer
+            options.AddSecurityDefinition("Basic Authentication", new OpenApiSecurityScheme
+            {
+                Type = SecuritySchemeType.Http,
+                In = ParameterLocation.Header,
+                Description = "Basic access authentication using the base64 encoding of a username and password joined by a single colon.",
+                Scheme = "basic"
+            });
+            options.OperationFilter<SwaggerAuthOperationFilter>();
+
+            var xmlFilename = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+            options.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, xmlFilename));
+        });
+
+        return services;
+    }
+}

--- a/MiniTwit.Server/MiniTwit.Server.csproj
+++ b/MiniTwit.Server/MiniTwit.Server.csproj
@@ -5,6 +5,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>0a60ddcd-86b0-42db-9216-996d71456e52</UserSecretsId>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MiniTwit.Server/Program.cs
+++ b/MiniTwit.Server/Program.cs
@@ -1,4 +1,4 @@
-using Microsoft.OpenApi.Models;
+using Microsoft.AspNetCore.Authentication;
 using MiniTwit.Core;
 using MiniTwit.Core.IRepositories;
 using MiniTwit.Infrastructure;
@@ -6,6 +6,7 @@ using MiniTwit.Infrastructure.Data;
 using MiniTwit.Infrastructure.Repositories;
 using MiniTwit.Security;
 using MiniTwit.Security.Hashers;
+using MiniTwit.Server.Authentication;
 using MiniTwit.Server.Extensions;
 using MiniTwit.Service;
 
@@ -25,18 +26,14 @@ builder.Services.Configure<MiniTwitDatabaseSettings>(options => options.Connecti
 builder.Services.Configure<HashSettings>(builder.Configuration.GetSection(nameof(HashSettings)));
 builder.Services.AddScoped<IHasher, Argon2Hasher>();
 
+// Add Basic Authentication
+builder.Services.AddAuthentication("BasicAuthentication").AddScheme<AuthenticationSchemeOptions, BasicAuthenticationHandler>("BasicAuthentication", options => {});
+builder.Services.AddAuthorization();
+
 builder.Services.AddControllers();
+
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen(options => {
-    options.SwaggerDoc("v1", new OpenApiInfo()
-    {
-        Title = "MiniTwit API",
-        Version = "v1",
-        Description = "A refactor of a Twitter clone handed out in the elective course DevOps on the IT University of Copenhagen.",
-        Contact = new OpenApiContact() { Name = "Group Radiator" },
-    });
-});
+builder.Services.ConfigureSwagger();
 
 builder.Services.AddScoped<IMongoDBContext, MongoDBContext>();
 builder.Services.AddScoped<IUserRepository, UserRepository>();
@@ -72,6 +69,7 @@ app.UseCors(x => x
 
 // app.UseHttpsRedirection();
 
+app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();


### PR DESCRIPTION
Implemented authentication/authorization of SimAPI using basic authentication schemes.

The scheme has been activated in Swagger as well. 
To use the endpoints requiring authentication use the username/password specified in `minitwit_simulator.py`